### PR TITLE
Fix get_request

### DIFF
--- a/core.py
+++ b/core.py
@@ -124,10 +124,10 @@ class Core(object):
         logger.info('Waiting for a 90 sec.')
         time.sleep(90)
         logger.info('Trying to get result...')
-        request = self.session.getResult(self.code)
         Dump.update(value='getRequest').where(Dump.param == 'lastAction').execute()
         max_count = self.cfg.GetResultMaxCount()
         for count in range(1, max_count + 1):
+            request = self.session.getResult(self.code)
             if request['result']:
                 logger.info('Got a dump ver. %s for the %s (INN %s)',
                             request['dumpFormatVersion'],


### PR DESCRIPTION
Из-за того что request создаётся один раз до цикла, неправильно работает условие "if request['result']:" Условие проверяет результат самого первого запроса при каждой итерации, вместо того чтобы ещё раз отправить запрос на проверку. Если дамп не собрался за 90 секунд, то все остальные повторы будут возвращать False.

После исправления при каждой итерации вызывается getResult. 